### PR TITLE
Helm v3.x support 🚢

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
 ENV KUBE_LATEST_VERSION="v1.16.2"
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v2.14.3"
+ENV HELM_VERSION="v3.3.4"
 
 RUN apk add --no-cache ca-certificates bash git openssh curl \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ kubectl: v1.16.2
 
 openshift-client: v3.11.0
 
-helm: v2.14.3
+helm: v3.3.4


### PR DESCRIPTION
Helmクライアントのバージョンを v3.3.4 にアップデートしました。